### PR TITLE
Tbillman patch 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ From there, you may wish to try [simulating a data set using AlphaSim](docs/alph
 
 If you have your own data prepared and in the appropriate format, please see [this tutorial](docs/datastore.md) for accessing the CyVerse data store from the command line.
 
-* 1. Setting up Agave
-* 2. [Simulation with Alphasim](docs/alphasim.md)
-* 3. GWAS tools
-* 4. [Winnow](docs/Winnow.md)
-* 5. [Demonstrate](docs/Demonstrate.md)
+1. Setting up Agave
+2. [Simulation with Alphasim](docs/alphasim.md)
+3. GWAS tools
+4. [Winnow](docs/Winnow.md)
+5. [Demonstrate](docs/Demonstrate.md)
 
 ## Old Workflow Guide:
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ From there, you may wish to try [simulating a data set using AlphaSim](docs/alph
 If you have your own data prepared and in the appropriate format, please see [this tutorial](docs/datastore.md) for accessing the CyVerse data store from the command line.
 
 * 1. Setting up Agave
-* [2. Simulation with Alphasim](docs/alphasim.md)
+* 2. [Simulation with Alphasim](docs/alphasim.md)
 * 3. GWAS tools
-* [4. Winnow](docs/Winnow.md)
-* [5. Demonstrate](docs/Demonstrate.md)
+* 4. [Winnow](docs/Winnow.md)
+* 5. [Demonstrate](docs/Demonstrate.md)
 
 ## Old Workflow Guide:
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,10 @@ If you have your own data prepared and in the appropriate format, please see [th
 
 ## Old Workflow Guide:
 
-[Workflow Guide](docs/workflow_documentation.md) 
+[Workflow Guide](docs/workflow_documentation.md)  
 
-[Working with your own Functions](docs/Your_functions.md)
-[Working with your own Simulations](docs/Your_sims.md)
+[Working with your own Functions](docs/Your_functions.md)  
+[Working with your own Simulations](docs/Your_sims.md)  
 
-[Further Winnow Development](docs/Winnow_develop.md)
-[Docker Tutorial](docs/docker_info/Docker_Tutorial.md)
-
-
+[Further Winnow Development](docs/Winnow_develop.md)  
+[Docker Tutorial](docs/docker_info/Docker_Tutorial.md)  

--- a/docs/Demonstrate.md
+++ b/docs/Demonstrate.md
@@ -92,4 +92,4 @@ These have default settings but can be changed by adding the argument after the 
 `python demonstrate.py --verbose --dir ~/Documents/Dem2InputFiles --output ~/Documents/Dem2Output --settings ~/Documents/Dem2InputFiles/winnowoutput.param demonstrate2 --postitle TPbyFP --errortitle AUCbyMAE --aucmin 0 --aucmax 1.5 --maemin 0 --maemax 2.5`
 
 
-[Back to Winnow](Winnow.md) | [Next: FaST-LMM Docs](FaST-LMM_Docs.md)
+[Back to Winnow](Winnow.md) | [Back to README](../README.md)

--- a/docs/Demonstrate.md
+++ b/docs/Demonstrate.md
@@ -92,4 +92,4 @@ These have default settings but can be changed by adding the argument after the 
 `python demonstrate.py --verbose --dir ~/Documents/Dem2InputFiles --output ~/Documents/Dem2Output --settings ~/Documents/Dem2InputFiles/winnowoutput.param demonstrate2 --postitle TPbyFP --errortitle AUCbyMAE --aucmin 0 --aucmax 1.5 --maemin 0 --maemax 2.5`
 
 
-[Back to Winnow](Winnow.md) | [Next: Installing Your Functions](Your\ functions.md)
+[Back to Winnow](Winnow.md) | [Next: FaST-LMM Docs](FaST-LMM_Docs.md)

--- a/docs/Demonstrate.md
+++ b/docs/Demonstrate.md
@@ -92,4 +92,4 @@ These have default settings but can be changed by adding the argument after the 
 `python demonstrate.py --verbose --dir ~/Documents/Dem2InputFiles --output ~/Documents/Dem2Output --settings ~/Documents/Dem2InputFiles/winnowoutput.param demonstrate2 --postitle TPbyFP --errortitle AUCbyMAE --aucmin 0 --aucmax 1.5 --maemin 0 --maemax 2.5`
 
 
-[Back to Winnow](Winnow.md) | [Back to README](../README.md)
+[Back to Winnow](Winnow.md) | [Back to Read ME](../README.md)

--- a/docs/Demonstrate.md
+++ b/docs/Demonstrate.md
@@ -1,4 +1,4 @@
-#Demonstrate
+# Demonstrate
 
 Demonstrate is the final step in the Validate known-truth pipeline for iPlant Collaborative. 
 Using output from Winnow, it produces a set of graphics showing differences in a GWAS/QTL applications performance under varying heritability and population structure. However,
@@ -6,7 +6,7 @@ Demonstrate also functions without the need for heritability or population struc
 
 The function you will want to use depends on what type of data you have:
 
-###Data with Heritability and Population Structure Specified 
+### Data with Heritability and Population Structure Specified 
 If you want to visualize differences in your data based on heritability or population structure, you'll want to use the
 original function Demonstrate. To run Demonstrate, type `R` on your terminal or command line to open the R console. From there use:
 
@@ -20,7 +20,7 @@ In this function, dir represents the directory where all Winnow output is stored
 on the mean absolute error (MAE) and area under the receiver operator curve (AUC) across varying levels of heritability and/or population structure.
 The graphs are in pdf format.
 
-###Other data from Winnow
+### Other data from Winnow
 For other types of data, or if you're more interested in comparing GWAS tools than comparing data, you will want to use the Demonstrate2 function. 
 Before running it though, you will need to include the function in your global environment:
 
@@ -36,7 +36,7 @@ file. Finally, two plots based on true vs. false positives and mean absolute err
 can compare multiple GWAS analysis results on the same plot.
 
 
-#Demonstrate With Python
+# Demonstrate With Python
 
 The Python implementation of Demonstrate works similar to the original program and provides the same output. The most important difference is the syntax to run the program. 
 
@@ -57,11 +57,11 @@ To run Demonstrate with only these settings; note the only 2 _required_ settings
 
 `python demonstrate.py --verbose --dir ~/Documents/Dem2InputFiles --output ~/Documents/Dem2Output --settings ~/Documents/Dem2InputFiles/winnowoutput.param demonstrate2`
 
-###Extra Parameters
+### Extra Parameters
 
 These have default settings but can be changed by adding the argument after the mode (e.g. after "demonstrate")
 
-####Demonstrate
+#### Demonstrate
 
 * **--xauc** (or **-a**) to exclude the AUC by Population Structure and Heritability plot (not set _by default_)
 * **--auctitle** (or **-t**) to specify the AUC plot title ("Mean AUC by Population Structure and Heritability" _by default_)
@@ -72,11 +72,11 @@ These have default settings but can be changed by adding the argument after the 
 * **--structstring** (or **-u**) to secify the structure string found in the input data ("PheHasStruct", "PheNPStruct" _by default_)
 * **--structvalue** (or **-p**) to specify the structure value found in the input data (True, False _by default_)
 
-#####Run Example (Including all plots)
+##### Run Example (Including all plots)
 
 `python demonstrate.py --verbose --dir ~/Documents/DemInputFiles --output ~/Documents/DemOutput --settings ~/Documents/DemInputFiles/winnowoutput.param demonstrate --auctitle AUC --maetitle MAE --heritstrig _03_ _04_ _06_ --heritvalue 0.3 0.4 0.6 --structstring PheHasStruct PheNPStruct --structvalue True False`
 
-####Demonstrate2
+#### Demonstrate2
 * **--xpos** (or **-q**) to exclude the True Positives by False Positives plot (not set _by default_)
 * **--postitle** (or **-i**) to specify the True Positives by False Positives plot title ("True Positives by False Positives _by default_)
 * **--xerror** (or **-e**) to exclude the error plot (not set _by default_)
@@ -87,9 +87,9 @@ These have default settings but can be changed by adding the argument after the 
 * **--maemin** (or **-n**) to specify minimum axis value for the MAE plot (0 _by default_)
 * **--maemax** (or **-c**) to specify minimum axis value for the MAE plot (2.0 _by default_)
 
-#####Run Example (Including all plots)
+##### Run Example (Including all plots)
 
 `python demonstrate.py --verbose --dir ~/Documents/Dem2InputFiles --output ~/Documents/Dem2Output --settings ~/Documents/Dem2InputFiles/winnowoutput.param demonstrate2 --postitle TPbyFP --errortitle AUCbyMAE --aucmin 0 --aucmax 1.5 --maemin 0 --maemax 2.5`
 
 
-[Back to Winnow](Winnow.md) | [Next: Installing Your Functions](Your functions.md)
+[Back to Winnow](Winnow.md) | [Next: Installing Your Functions](Your\ functions.md)

--- a/docs/FaST-LMM_Docs.md
+++ b/docs/FaST-LMM_Docs.md
@@ -35,4 +35,4 @@ An example of executing the FaST-LMM program might look like so:
 
 [Sample Data](http://mirrors.iplantcollaborative.org/browse/iplant/home/shared/iplantcollaborative/example_data/fastlmm)  
 
-[Back to Workflow Documentation](workflow\ documentation.md) | [Next: GEMMA](GEMMA\ Doc.md)
+[Back to Workflow Documentation](workflow\ documentation.md) | [Next: GEMMA](GEMMA_Doc.md)

--- a/docs/FaST-LMM_Docs.md
+++ b/docs/FaST-LMM_Docs.md
@@ -1,10 +1,10 @@
-#FaST-LMM
+# FaST-LMM
 
 *(Links to sample data, the user manual, and another tutorial are available at the bottom of this page)*
 
 >The main genome wide association studies tool that we have used, FaST-LMM stands for *Fa*ctored *S*pectrally *T*ransformed *L*inear *M*ixed *M*odels. It is a tool from Microsoft Research designed for analyses of very large data sets, and has been tested on data sets with over 120,000 individuals.
 
-##Running the Program
+## Running the Program
 
 **The program requires a minimum of three files to function:** 
 
@@ -28,9 +28,9 @@
 An example of executing the FaST-LMM program might look like so:
 `fastlmmc -verboseOutput -bfile toydata -pheno toydata.phe.txt -covar toydata.covar.txt -out MyResults.csv`
 
-####**Additional information** 
+#### **Additional information** 
 [Tutorial on iPlant confluence Wiki](https://pods.iplantcollaborative.org/wiki/display/TUT/FaST-LMM)<br></br>
 [User Manual](http://nbviewer.ipython.org/github/MicrosoftGenomics/FaST-LMM/blob/master/doc/ipynb/FaST-LMM.ipynb)<br></br>
 [Sample Data](http://mirrors.iplantcollaborative.org/browse/iplant/home/shared/iplantcollaborative/example_data/fastlmm)
 
-[Back to Workflow Documentation](workflow documentation.md) | [Next: GEMMA](GEMMA Doc.md)
+[Back to Workflow Documentation](workflow\ documentation.md) | [Next: GEMMA](GEMMA\ Doc.md)

--- a/docs/FaST-LMM_Docs.md
+++ b/docs/FaST-LMM_Docs.md
@@ -35,4 +35,4 @@ An example of executing the FaST-LMM program might look like so:
 
 [Sample Data](http://mirrors.iplantcollaborative.org/browse/iplant/home/shared/iplantcollaborative/example_data/fastlmm)  
 
-[Back to Workflow Documentation](workflow\ documentation.md) | [Next: GEMMA](GEMMA_Doc.md)
+[Back to Workflow Documentation](workflow_documentation.md) | [Next: GEMMA](GEMMA_Doc.md)

--- a/docs/FaST-LMM_Docs.md
+++ b/docs/FaST-LMM_Docs.md
@@ -29,8 +29,7 @@ An example of executing the FaST-LMM program might look like so:
 `fastlmmc -verboseOutput -bfile toydata -pheno toydata.phe.txt -covar toydata.covar.txt -out MyResults.csv`
 
 #### **Additional information** 
-[Tutorial on iPlant confluence Wiki](https://pods.iplantcollaborative.org/wiki/display/TUT/FaST-LMM)<br></br>
-[User Manual](http://nbviewer.ipython.org/github/MicrosoftGenomics/FaST-LMM/blob/master/doc/ipynb/FaST-LMM.ipynb)<br></br>
-[Sample Data](http://mirrors.iplantcollaborative.org/browse/iplant/home/shared/iplantcollaborative/example_data/fastlmm)
-
+[Tutorial on iPlant confluence Wiki](https://pods.iplantcollaborative.org/wiki/display/TUT/FaST-LMM)  
+[User Manual](http://nbviewer.ipython.org/github/MicrosoftGenomics/FaST-LMM/blob/master/doc/ipynb/FaST-LMM.ipynb)  
+[Sample Data](http://mirrors.iplantcollaborative.org/browse/iplant/home/shared/iplantcollaborative/example_data/fastlmm)  
 [Back to Workflow Documentation](workflow\ documentation.md) | [Next: GEMMA](GEMMA\ Doc.md)

--- a/docs/FaST-LMM_Docs.md
+++ b/docs/FaST-LMM_Docs.md
@@ -30,6 +30,9 @@ An example of executing the FaST-LMM program might look like so:
 
 #### **Additional information** 
 [Tutorial on iPlant confluence Wiki](https://pods.iplantcollaborative.org/wiki/display/TUT/FaST-LMM)  
+
 [User Manual](http://nbviewer.ipython.org/github/MicrosoftGenomics/FaST-LMM/blob/master/doc/ipynb/FaST-LMM.ipynb)  
+
 [Sample Data](http://mirrors.iplantcollaborative.org/browse/iplant/home/shared/iplantcollaborative/example_data/fastlmm)  
+
 [Back to Workflow Documentation](workflow\ documentation.md) | [Next: GEMMA](GEMMA\ Doc.md)

--- a/docs/GEMMA_Doc.md
+++ b/docs/GEMMA_Doc.md
@@ -1,4 +1,4 @@
-#GEMMA
+# GEMMA
 
 *(Links to the user manual, and another tutorial are available at the bottom of this page)*
 
@@ -64,8 +64,9 @@ For the multivariate mixed model, the only additional command line argument requ
 
 * **-n:** One or more integers separated by spaces; indicates which phenotype values in the phenotype file (whether PLINK binary or BIMBAM format) are included in the association analysis.
 
-####**Additional information** 
-[Tutorial on iPlant confluence Wiki](https://pods.iplantcollaborative.org/wiki/display/TUT/GEMMA)<br></br>
-[User Manual](http://www.xzlab.org/software/GEMMAmanual.pdf)<br></br>
+#### **Additional information** 
+[Tutorial on iPlant confluence Wiki](https://pods.iplantcollaborative.org/wiki/display/TUT/GEMMA)  
 
-[Back to Workflow Documentation](workflow documentation.md) | [Next: Qxpak](Qxpak.md)
+[User Manual](http://www.xzlab.org/software/GEMMAmanual.pdf)  
+
+[Back to Workflow Documentation](workflow_documentation.md) | [Next: Qxpak](Qxpak.md)

--- a/docs/PLINK.md
+++ b/docs/PLINK.md
@@ -146,4 +146,4 @@ Any of these analyses outputs may be run through Winnow and therefore are compat
 [Sample data](http://mirrors.iplantcollaborative.org/browse/iplant/home/shared/syngenta_sim/PEDMAP_DE) (WARNING: Very large datasets)<br></br>
 
 
-[Back to Workflow Documentation](workflow documentation.md) | [Next: Winnow](Winnow.md)
+[Back to Workflow Documentation](workflow\ documentation.md) | [Next: Winnow](Winnow.md)

--- a/docs/PLINK.md
+++ b/docs/PLINK.md
@@ -1,4 +1,4 @@
-#PLINK: An Open-Source Whole Genome Association Analysis Toolset
+# PLINK: An Open-Source Whole Genome Association Analysis Toolset
 
 *(Links to sample data, the user manual, and another tutorial are available at the bottom of this page)*
 
@@ -10,14 +10,14 @@ In the context of the Validate Workflow, PLINK is useful for handling both linea
 Though PLINK's analysis algorithms may not be quite as thorough as other mixed model software's, 
 it is a versatile GWAS (genome wide association studies) tool for handling dosage analysis, genotype-environment interactions, epistasis, and data management.
 
-##Input File Formats
+## Input File Formats
 
 **NOTE:** For most any type of command you run in PLINK, the program will initially try and connect to the Internet to download the latest version of the software. 
 Because this process is often unnecessary and time-consuming, we recommend using the `--noweb` flag in each of your commands to tell PLINK not to update.
 
 The file formats PLINK uses for genotype data fall into several different groups:
 
-####**PED/MAP files** 
+#### **PED/MAP files** 
 ------
 Standard files with .ped and .map extensions detailing the genotype information of an individual or a group of individuals. The PED file is delimited by spaces or tabs, and the first six columns of a PED file must correspond to the following: 
 *Family ID*, *Individual ID*, *Paternal ID*, *Maternal ID*, *Sex*, and *Phenotype.* The MAP file is a description of each genetic marker, and this file must have exactly 4 columns:
@@ -33,7 +33,7 @@ Alternatively, if the PED and MAP files have different names, use these commands
 
 If certain columns of the PED files are missing, the flags `--no-parents`, `--no-sex`, and `--no-pheno` may be used to denote PED files without the paternal and maternal IDs, sex, or phenotype respectively.
 
-####**BED/BIM/FAM files** 
+#### **BED/BIM/FAM files** 
 ------
 Binary equivalents of the PED/MAP files. Because of the conversion to binary, these files take up far less storage space and can be more efficiently loaded than an equivalent PED/MAP set would. 
 Furthermore, do not attempt to read the BED file; it is a compressed file and a text editor will only show strange characters when opening the BED file. 
@@ -44,7 +44,7 @@ To run BED/BIM/FAM files, use this commmand:
 
   `plink --bfile <binary dataset name, sans extension>`
 
-####**TPED/TFAM files** 
+#### **TPED/TFAM files** 
 ------
 These files represent a transposed fileset. 
 The first 4 columns of a TPED file are the same as a standard 4-column MAP file. Then, all genotypes are listed for all individuals for each particular SNP on each line. 
@@ -60,7 +60,7 @@ In some cases, PLINK also supports covariates in a given dataset. A covariate fi
 
   `plink --file <dataset> --covar <covariate file, plus extension>`
 
-##File Format Conversion
+## File Format Conversion
 
 Depending on your purpose for your data, occasionally conversion between PLINK formats may be necessary. 
 Fortunately, PLINK is very efficient in this regard, and even extremely large datasets can be converted in a reasonable amount of time.
@@ -83,7 +83,7 @@ Finally, to convert a binary or transposed file set back to its original PED/MAP
 
   `plink --bfile or --tfile <dataset name> --recode --out <new dataset name>`
 
-##Data Analysis
+## Data Analysis
 
 PLINK is also capable of running many types of basic quantitative analyses including epistasis, dosage analysis, and meta-analysis. For the purposes of this tutorial, however, we will only focus on the three algorithms for quantitative trait association.<br></br> 
 **First**<br></br>
@@ -141,9 +141,10 @@ For both of these options, the standard columns in the output files will be the 
 
 Any of these analyses outputs may be run through Winnow and therefore are compatible with the rest of the Validate Workflow (so long as a known-truth file is available as well).
 
-[Tutorial on iPlant confluence Wiki](https://pods.iplantcollaborative.org/wiki/display/DEapps/PLINK)<br></br>
-[PLINK documentation](http://pngu.mgh.harvard.edu/~purcell/plink/index.shtml)<br></br>
-[Sample data](http://mirrors.iplantcollaborative.org/browse/iplant/home/shared/syngenta_sim/PEDMAP_DE) (WARNING: Very large datasets)<br></br>
+[Tutorial on iPlant confluence Wiki](https://pods.iplantcollaborative.org/wiki/display/DEapps/PLINK)  
 
+[PLINK documentation](http://pngu.mgh.harvard.edu/~purcell/plink/index.shtml)  
 
-[Back to Workflow Documentation](workflow\ documentation.md) | [Next: Winnow](Winnow.md)
+[Sample data](http://mirrors.iplantcollaborative.org/browse/iplant/home/shared/syngenta_sim/PEDMAP_DE) (WARNING: Very large datasets)  
+
+[Back to Workflow Documentation](workflow_documentation.md) | [Next: Winnow](Winnow.md)

--- a/docs/Qxpak.md
+++ b/docs/Qxpak.md
@@ -1,17 +1,17 @@
-#Qxpak v.5
+# Qxpak v.5
 
 *(Links to sample data, the user manual, and another tutorial are available at the bottom of this page)*
 
 
 >Qxpak is a package for versatile statistical genomics, specifically designed for sophisticated quantitative trait loci and association analyses. Multiple loci, multiple trait, infinitesimal genetic effects, imprinting, epistasis or sex linked loci can be fitted. The new version (v. 5) allows us, among other new features, to include either relationship matrices obtained with molecular information or user defined matrices that can be read from an input file. This feature can be used for genome selection or - more importantly - to correct for population structure in association studies. In crosses, two parental lines, not necessarily inbred, can be accommodated --<cite>[QxPak Manual](http://nce.ads.uga.edu/~ignacy/numpub/blupf90/docs/qxpak.pdf)</cite>
 
-###**Inputs**
+### **Inputs**
 Qxpak normally requires four files: 
 
 1. parameter file with input details
 2. data file containing phenotypes and any effect that may be included in the model
 3. pedigree file with genotypes
-4.  marker file with genotypes.
+4. marker file with genotypes.
 
 
 
@@ -48,7 +48,7 @@ The format of these files is: row, column, value in space-delimited form like th
 **Haplotype File**
 Contains known haplotypes if any. The first record contains the name of the chromosome. Successive records include individual, order of markers where phases known. If several chromosomes are analyzed, the format should be repeated for each.
 
-###**Outputs**
+### **Outputs**
 
 **q.0**
 Contains running output that might be useful for, among other things, checking convergence.
@@ -65,7 +65,7 @@ Z files contain the IDB probabilities or SNP configurations.
 **Other Output Files**
 There are numerous other undocumented output files.
 
-###**Wrapper Script**
+### **Wrapper Script**
 There is also a wrapper script available [here](https://pods.iplantcollaborative.org/wiki/download/attachments/8406442/qxpakwrapper.py?version=1&modificationDate=1341604484000&api=v2) and also linked on the Qxpak [wikipage](https://pods.iplantcollaborative.org/wiki/display/DEapps/Qxpak).
 This allows the user to write in the parameters directly into the command line without having to edit the parameter file repeatedly. 
 
@@ -85,9 +85,11 @@ A sample code with the wrapper used would look like…
 
     qxpakwrapper.py -p parameterFile.par -d dataFile.dat -g pedigreeFile.ped -m markerFile.mkr -i userInverse.inverse -t UserDirect.direct -h haplotypes.haplo -o results.csv
 
-####**Additional information** 
-[Tutorial on iPlant confluence Wiki](https://pods.iplantcollaborative.org/wiki/display/TUT/Qxpak)<br></br>
-[User Manual](http://nce.ads.uga.edu/~ignacy/numpub/blupf90/docs/qxpak.pdf)<br></br>
-[Sample Data](http://mirrors.iplantcollaborative.org/browse/iplant/home/shared/iplantcollaborative/example_data/qxpak)<br></br>
+#### **Additional information** 
+[Tutorial on iPlant confluence Wiki](https://pods.iplantcollaborative.org/wiki/display/TUT/Qxpak)  
 
-[Back to Workflow Documentation](workflow documentation.md) | [Next: PLINK](PLINK.md)
+[User Manual](http://nce.ads.uga.edu/~ignacy/numpub/blupf90/docs/qxpak.pdf)  
+
+[Sample Data](http://mirrors.iplantcollaborative.org/browse/iplant/home/shared/iplantcollaborative/example_data/qxpak)  
+
+[Back to Workflow Documentation](workflow_documentation.md) | [Next: PLINK](PLINK.md)

--- a/docs/Simulate.md
+++ b/docs/Simulate.md
@@ -24,4 +24,4 @@ One example of running Simulate would look like so:
 Note that here we have two subpopulations with 1000 individuals each. These individuals then have 3000 markers and three loci with effects. Those effect sizes are all equal at 0.2, and the population mean for both subpopulations is 2.7 (if no second mean is listed, the program will just duplicate the first mean). These populations will both evolve for 100 generations and the heritabity value of the phenotype is 0.25. Finally, the three output files will be moved to the desktop, all beginning with the word "Test."
 At the time of this writing, conversion to different formats will need to be done manually; however, exporting of data to other file formats will be an option in coming updates of the Simulate program.
 
-[Back to Workflow Documentation](.workflow\ documentation.md) | [Next: FaST-LMM](FaST-LMM\ Docs.md)
+[Back to Workflow Documentation](workflow_documentation.md) | [Next: FaST-LMM](FaST-LMM_Docs.md)

--- a/docs/Simulate.md
+++ b/docs/Simulate.md
@@ -1,4 +1,4 @@
-#Simulate
+# Simulate
 Unless you already have simulation data stored or uploaded onto your instance, you may want to start out using *Simulate*, the first step of the workflow. Since Simulate is stored in the /usr/bin directory, either change your location to that folder or use `python /usr/bin/Simulate.py` when running the program. The options for Simulate are:
 * **Verbose mode:** `-v` or `--verbose`
 * **Population size(s):** `-s` or `--size`*
@@ -24,4 +24,4 @@ One example of running Simulate would look like so:
 Note that here we have two subpopulations with 1000 individuals each. These individuals then have 3000 markers and three loci with effects. Those effect sizes are all equal at 0.2, and the population mean for both subpopulations is 2.7 (if no second mean is listed, the program will just duplicate the first mean). These populations will both evolve for 100 generations and the heritabity value of the phenotype is 0.25. Finally, the three output files will be moved to the desktop, all beginning with the word "Test."
 At the time of this writing, conversion to different formats will need to be done manually; however, exporting of data to other file formats will be an option in coming updates of the Simulate program.
 
-[Back to Workflow Documentation](./workflow documentation.md) | [Next: FaST-LMM](FaST-LMM Docs.md)
+[Back to Workflow Documentation](.workflow\ documentation.md) | [Next: FaST-LMM](FaST-LMM\ Docs.md)

--- a/docs/Stampede-guide.md
+++ b/docs/Stampede-guide.md
@@ -1,11 +1,11 @@
-#A Quick Guide to Stampede for Beginning Users
+# A Quick Guide to Stampede for Beginning Users
 
 **NOTE:** This guide is intended for users who are unfamiliar with the basics 
 of the Stampede supercomputer or only have a cursory knowledge of the system. 
 For more advanced documentation, please consult one
 of the other pages in this repository or the [TACC User Guide](https://portal.tacc.utexas.edu/user-guides/stampede).
 
-##Intro
+## Intro
 
 For those of you who are new to the [Stampede system](https://portal.tacc.utexas.edu/user-guides/stampede), first of all, congratulations on gaining access to one of the most powerful computers on Earth! 
 We hope that Stampede will be useful in whatever research you are conducting. Before you start, please make sure that all your accounts are in place.
@@ -13,7 +13,7 @@ To check which accounts you need, refer to the [Accounts Setup page.](https://gi
 Also, using Stampede requires at least a basic familiarity with Linux commands and the command line interface (CLI), so if you are lacking there, please consult this
 [Linux cheat sheet](http://linoxide.com/images/linux-cheat-sheet-612x792.png) or the [Software Carpentry shell tutorials](http://swcarpentry.github.io/shell-novice/)
 
-##Differences from Linux Terminal
+## Differences from Linux Terminal
 
 While the Stampede shell *does* operate under a Linux operating system (OS) and runs bash commands, Stampede is slightly different from a typical Linux terminal.
 How so? In one sense, Stampede has many capabilities beyond what a typical Linux shell can do since it is essentially a large compute cluster rather than a standalone computer; 
@@ -71,7 +71,7 @@ the `module spider` command to do so. For example, if you wish to search for a p
 
 A series of commands for running iPlant applications are also covered in the next section. 
 
-##Setting Up and Running Apps
+## Setting Up and Running Apps
 
 Regarding apps, through the Agave API, Stampede provides a number of scientific apps that may be combined with the full power of the supercomputer. Most of the apps deal with life sciences, and to see the full list of applications available, use
 the command `apps-list`. If you wish to submit an app of your own, you will need a few things set up in a folder either on Stampede or on the iPlant Data Store beforehand:
@@ -114,7 +114,7 @@ And that about covers it! You should now be able to navigate the Stampede system
 
 **Also, if you want a list of all available commands on Stampede under a certain umbrella (like apps or jobs), type `compgen -c <search term here>` (for example, `compgen -c 'apps' `)** 
 
-##Using the Workflow on Stampede
+## Using the Workflow on Stampede
 
 While the apps will be available through Agave in the near future, for now you are free to upload them from Github and run through batch processing. To upload from Github, take these steps:
 
@@ -132,4 +132,4 @@ Either way, you may run analyses through batch processing and SLURM commands. Fo
 Once the apps are available through Agave, you can just submit a job description like the example linked above to get things running. To submit your job description and get a job started, just
 use the `jobs-submit` command corresponding to whatever app you want to run. Make sure you have all of the outputs directed to the right place, along with the links to whatever input you may be using.
 
-[Back to Read Me](../README.md) | [Next: Workflow guide](workflow documentation.md)
+[Back to Read Me](../README.md) | [Next: Workflow guide](workflow_documentation.md)

--- a/docs/Winnow.md
+++ b/docs/Winnow.md
@@ -31,8 +31,8 @@ Other possible arguments include:
 For the --kttype argument, the two possible options are "OTE" or "FGS." The "OTE" format represents "Only Truth and Effect," meaning that only those SNPs with significant effects along with the effect size of those significant SNPs are included in the known-truth file. The "FGS" format means "Full Genome Set," meaning that all SNPs and effects are included.  
 
 #### **Additional information** 
-[Tutorial on iPlant confluence Wiki](https://pods.iplantcollaborative.org/wiki/display/TUT/Winnow)<br></br>
-[Sample Data](http://datacommons.cyverse.org/browse/iplant/home/shared/iplantcollaborative/example_data/Validate/Validate_Test_Data)<br></br>
+[Tutorial on iPlant confluence Wiki](https://pods.iplantcollaborative.org/wiki/display/TUT/Winnow)  
 
+[Sample Data](http://datacommons.cyverse.org/browse/iplant/home/shared/iplantcollaborative/example_data/Validate/Validate_Test_Data)  
 
 [Back to PLINK](PLINK.md) | [Additional: Winnow Development](Winnow_develop.md) | [Next: Demonstrate](Demonstrate.md)

--- a/docs/Winnow.md
+++ b/docs/Winnow.md
@@ -1,10 +1,10 @@
-#Winnow
+# Winnow
 *(Links to sample data, and another tutorial are available at the bottom of this page)*
 
 >The bread-and-butter of the workflow, Winnow (formerly the eponymous Validate), is a Python-compatible known truth testing tool for genome wide association studies. Quite simply, Winnow is a tool that evaluates other tools. 
 Winnow requires output from a GWAS tool after analyzing a data set. Given the "known truth" of the original data set, Winnow outputs a series of fit statistics to determine the validity of the GWAS tool and whether or not it was truly useful in analyzing the data.
 
-###Winnow Guide
+### Winnow Guide
 
 On the _Validate Workflow v0.5_ Atmosphere instance, the main Winnow program, `winnow.py`, is located in the `/usr/bin` directory along with its modules. To see all of the possible options, type this command into the terminal/command line:
 

--- a/docs/Winnow.md
+++ b/docs/Winnow.md
@@ -35,4 +35,4 @@ For the --kttype argument, the two possible options are "OTE" or "FGS." The "OTE
 [Sample Data](http://datacommons.cyverse.org/browse/iplant/home/shared/iplantcollaborative/example_data/Validate/Validate_Test_Data)<br></br>
 
 
-[Back to PLINK](PLINK.md) | [Additional: Winnow Development](Winnow develop.md) | [Next: Demonstrate](Demonstrate.md)
+[Back to PLINK](PLINK.md) | [Additional: Winnow Development](Winnow\ develop.md) | [Next: Demonstrate](Demonstrate.md)

--- a/docs/Winnow.md
+++ b/docs/Winnow.md
@@ -35,4 +35,4 @@ For the --kttype argument, the two possible options are "OTE" or "FGS." The "OTE
 [Sample Data](http://datacommons.cyverse.org/browse/iplant/home/shared/iplantcollaborative/example_data/Validate/Validate_Test_Data)<br></br>
 
 
-[Back to PLINK](PLINK.md) | [Additional: Winnow Development](Winnow\ develop.md) | [Next: Demonstrate](Demonstrate.md)
+[Back to PLINK](PLINK.md) | [Additional: Winnow Development](Winnow_develop.md) | [Next: Demonstrate](Demonstrate.md)

--- a/docs/Winnow.md
+++ b/docs/Winnow.md
@@ -30,7 +30,7 @@ Other possible arguments include:
 
 For the --kttype argument, the two possible options are "OTE" or "FGS." The "OTE" format represents "Only Truth and Effect," meaning that only those SNPs with significant effects along with the effect size of those significant SNPs are included in the known-truth file. The "FGS" format means "Full Genome Set," meaning that all SNPs and effects are included.  
 
-####**Additional information** 
+#### **Additional information** 
 [Tutorial on iPlant confluence Wiki](https://pods.iplantcollaborative.org/wiki/display/TUT/Winnow)<br></br>
 [Sample Data](http://datacommons.cyverse.org/browse/iplant/home/shared/iplantcollaborative/example_data/Validate/Validate_Test_Data)<br></br>
 

--- a/docs/Winnow_develop.md
+++ b/docs/Winnow_develop.md
@@ -1,4 +1,4 @@
-#A Small Guide to Further Winnow Development
+# A Small Guide to Further Winnow Development
 
 Because of the structure of the Winnow program, it is easy to add in any 
 additional performance metrics that you may wish to include in your final analysis. This documentation is intended to provide a comprehensive manual of how to add to Validate and/or alter Validate in any way to provide a more useful way to test genotype to phenotype association methods with known-truth data sets. 
@@ -35,7 +35,7 @@ You will also need to understand the following five objects from the program to 
 | scoreColumn   | This list is the list of generated "scores" reflecting the score assigned to that SNP from the GWAS application. For example, this is the column that would be generally indicated for P-values                                                                                                                                   |
 | threshold     | This is a scalar quantity designed for some metrics that require a threshold such as True Positive Rate, for example.                                                                                                                                                                                                             |
 
-##Adding a performance metric
+## Adding a performance metric
 
 Adding an additional fit statistic to the list of outputs is fortunately very straightforward. As a basic example, if we wanted to include a correlation value:
 
@@ -55,7 +55,7 @@ def r(betaColumn, betaTrueFalse):
 You will need to include the function name—"r" in this case—and the function call—r(betaColumn, betaTrueFalse)—in the file. 
 Remember also that we are only changing the gwaswithBeta function, as we could not analyze a GWAS application that did not include SNP weights.
 
-##Adding a P-value adjustment function
+## Adding a P-value adjustment function
 
 If we wanted to include a Benjamini-Hochberg FDR adjustment:
 

--- a/docs/Your_functions.md
+++ b/docs/Your_functions.md
@@ -51,4 +51,4 @@ From there, in addition to the source code, you will need a Javascript Object No
 For a more in-depth explanation of the requirements, please consult [this tutorial](https://github.com/iPlantCollaborativeOpenSource/iplant-agave-sdk)
 
 
-[Back to Read Me](../README.md) | [Next: Installing your simulations](Your\ sims.md)
+[Back to Read Me](../README.md) | [Next: Installing your simulations](Your_sims.md)

--- a/docs/Your_functions.md
+++ b/docs/Your_functions.md
@@ -1,10 +1,10 @@
-#Installing your own functions
+# Installing your own functions
 
 Though the Validate Workflow—on both Atmosphere and Stampede—provides a number of options for GWAS analysis tools, you are
 also able to bring your own methods in for use. As long as the output from your function is in the proper style (*not* necessarily file format),
 then you can easily integrate it into the workflow.
 
-##Bringing in your own functions
+## Bringing in your own functions
 
 On Atmosphere and Stampede both, bringing in your own methods are not terribly difficult. 
 All you need is the source code, a terminal, and access to the rest of the Workflow.
@@ -33,7 +33,7 @@ Another column that may be included is:
 4) If you are aiming to make permanent your source code either on an Atmosphere instance or on Stampede, 
 you'll need to do another few things:
 
-###If on Atmosphere:
+### If on Atmosphere:
 The key thing you will need to do is move your source code/executable to a permanent location on the instance. 
 **Do not leave anything you want to save on the Desktop or your personal directory!** 
 Instead, it's recommended that you move everything either to the `usr` or `usr/bin` folder for imaging. 
@@ -43,7 +43,7 @@ Once you have everything moved to a permanent directory, simply go back to the A
 **NOTE:** Even after you fill out the image forms, do not terminate the instance immediately! Atmosphere will need to "take a picture" of your instance, which may take a few minutes.
 During that time, please keep your instance either *active* or *suspended.*
 
-##If on Stampede
+## If on Stampede
 Getting your app permanently, formally recognized on Stampede involves a bit more effort. 
 To list an app on Stampede, you'll need to go through the Agave API and the app submission process there. 
 To get started, you'll need to [set up the necessary accounts](Account-setup.md). 
@@ -51,4 +51,4 @@ From there, in addition to the source code, you will need a Javascript Object No
 For a more in-depth explanation of the requirements, please consult [this tutorial](https://github.com/iPlantCollaborativeOpenSource/iplant-agave-sdk)
 
 
-[Back to Read Me](../README.md) | [Next: Installing your simulations](Your sims.md)
+[Back to Read Me](../README.md) | [Next: Installing your simulations](Your\ sims.md)

--- a/docs/Your_sims.md
+++ b/docs/Your_sims.md
@@ -1,4 +1,4 @@
-##Installing your own simulations
+# Installing your own simulations
 
 Like the other page in this repository regarding [installation of your own functions,](Your functions.md) the Validate Workflow is also adaptable to 
 any of your own simulations that you would like to use. 
@@ -6,7 +6,7 @@ To install your own simulations, follow the same steps found on the aforemention
 For simulations, keep in mind that your final file formats must be compatible with whatever analysis tool you are using; 
 therefore, if your analysis tool of choice only takes PLINK format, for example, be sure that your simulation data outputs in PED/MAP or BED/BIM/FAM formats.
 
-##Bringing simulation outputs to Atmosphere
+## Bringing simulation outputs to Atmosphere
 
 Another option, rather than moving your simulation software directly to the computing environment, 
 is to just save the simulation output to the Data Store and send the simulation output to the computing environment instead. There's only one catch: depending on the size of your simulation files,
@@ -16,7 +16,7 @@ transporting *everything* may take some time. If you still wish to do so, a numb
 2) An SFTP client like WinSCP or Cyberduck
 3) Git (only for files < 100 MB and/or repos < 1 GB)
 
-##IRODs
+## IRODs
 
 iRODs is one of the programs that integrates the iPlant Collaborative together; it allows for Data Store connectivity to other services like Atmosphere.
 To set up iRODs, type `iinit` on Atmosphere (since iRODs is built in) or on Stampede type `module load irods`, then `iinit`. 
@@ -28,14 +28,14 @@ directory, type `ils`; if you wish to change your current directory, type `icd`;
 is `iget <path.to.file>`. Many flag options exist for each of these commands, and if you want to view them in more detail [check out the iRODs wiki.](https://wiki.irods.org/index.php/icommands). 
 Most files will take less than 60 seconds to download assuming they are less than 2 GB each.
 
-##SFTP client
+## SFTP client
 
 Most secure file transfer protocol (SFTP) clients normally have a type of interface which makes file transfer easier. 
 For instance, WinSCP has a drag-and-drop interface which allows for transporting files to a secure shell (like Stampede) en masse.
 One thing of note regarding SFTP clients is that most may take longer than iRODs when transferring larger files; 
 however, nothing beyond the file and the client are needed to actually make the transfer.
 
-##Git
+## Git
 
 Using Git is perhaps a last resort for transferring files, in part because it requires both a Github account and that your files are less than 100 MB each.
 If your simulation output is stored in a Github repository, however, you may use git to clone/copy it into your current location.
@@ -47,4 +47,4 @@ in your current directory. From here, use the outputs to your heart's content.
 On Stampede, type `module load git` then `git clone <repo URL>` to create a copy of the entire repository in your current directory.
 Ideally, you will want to move everything to your working directory since it has far more storage space than the home directory.
 
-[Back to Read Me](../README.md) | [Next: Further Developing Winnow](Winnow develop.md)
+[Back to Read Me](../README.md) | [Next: Further Developing Winnow](Winnow_develop.md)

--- a/docs/alphasim.md
+++ b/docs/alphasim.md
@@ -7,10 +7,10 @@ Prerequisites: Agave CLI, general knowledge of executing using Agave, Access to 
 
 Helpful Documentation
 
-Alphasim: http://www.alphagenes.roslin.ed.ac.uk/wp-content/uploads/AlphaSimManual/AlphaSim.html
-Alphasim parameter file: https://github.com/CyVerse-Validate/Stampede-Files/blob/master/AlphaSim-1.04/AlphaSimInputInformation.txt
+[Alphasim](http://www.alphagenes.roslin.ed.ac.uk/wp-content/uploads/AlphaSimManual/AlphaSim.html)  
+[Alphasim's parameter file](https://github.com/CyVerse-Validate/Stampede-Files/blob/master/AlphaSim-1.04/AlphaSimInputInformation.txt)
 
-##Locate / Open parameter file
+## Locate / Open parameter file
 
 You can download a sample parameter files from our repository. The parameter file allows you to pass commands into the AlphaSim software.
 Once you have access the parameter file, upload it to your Data Store. The default parameter file has specifications for running multiple generations for corn genetics.
@@ -58,7 +58,7 @@ https://github.com/CyVerse-Validate/Stampede-Files/blob/master/AlphaSim-1.04/get
 
 ## Convert to ped/map
 
-1. Download the merger.py from the github repository here (or if you have already installed Validate, it is included): https://github.com/CyVerse-Validate/Validate/tree/master/CurrentReleaseStable/Util_1/Merger
+1. Download the merger.py from the github repository [here](https://github.com/CyVerse-Validate/Validate/tree/master/CurrentReleaseStable/Util_1/Merger) (or if you have already installed Validate, it is included): 
 
 2. Run the merger with the AlphaSim outputs with the following commands from the directory where your AlphaSim output is located, where ALPHASIMPREFIX is the prefix of your job output:
 
@@ -70,7 +70,7 @@ This will yield ALPHASIMPREFIX.ped and ALPHASIMPREFIX.map in the directory speci
 
 ## Convert to bed/bim/fam
 
-1. Download plink from the github repository here (or if you have already installed Validate, it is included): https://github.com/CyVerse-Validate/Validate/blob/master/CurrentReleaseStable/GWAS_1/plink
+1. Download plink from the github repository [here](https://github.com/CyVerse-Validate/Validate/blob/master/CurrentReleaseStable/GWAS_1/plink) (or if you have already installed Validate, it is included): 
 
 2. Run Plink with the following command from the directory where your ped/map files are located:
 

--- a/docs/workflow_documentation.md
+++ b/docs/workflow_documentation.md
@@ -2,11 +2,10 @@ Check the following links for guides to each part of the workflow:
 
 1. [Simulate](Simulate.md)
 2. GWAS Tools
-
-  * [FaST-LMM](FaST-LMM_Docs.md)
-  * [GEMMA](GEMMA_Doc.md)
-  * [Qxpak](Qxpak.md)
-  * [PLINK](PLINK.md)
+    * [FaST-LMM](FaST-LMM_Docs.md)
+    * [GEMMA](GEMMA_Doc.md)
+    * [Qxpak](Qxpak.md)
+    * [PLINK](PLINK.md)
 3. [Winnow](Winnow.md)
 4. [Demonstrate](Demonstrate.md)
 


### PR DESCRIPTION
I fixed a lot of the formatting errors present in the guide. A The headers were were not in the correct syntax, and were showing up as ####header instead of an actual header. Additionally, since file names were changed, many of the links at the bottom of the page gave 404 errors. I fixed these links so they take the user to the appropriate location. Another minor edit was that some of the line breaks in between links looked off, so I regularly spaced them.